### PR TITLE
Implement checking out

### DIFF
--- a/app/models/check-in.js
+++ b/app/models/check-in.js
@@ -66,5 +66,33 @@ var CheckIn = BaseModel.extend( {
 } );
 
 
+/**
+ * Find a check in by id
+ */
+CheckIn.findById = function findById( id, options ) {
+
+  if ( id ) {
+
+    return new CheckIn( {
+      id: id
+    } )
+      .fetch( options )
+      .then( function( checkIn ) {
+
+        if ( checkIn ) {
+          return checkIn;
+        } else {
+          throw new ResponseError( 'notFound' );
+        }
+
+      } );
+
+  } else {
+    throw new ResponseError( 'notFound' );
+  }
+
+};
+
+
 // Exports
 module.exports = db.bookshelf.model( 'CheckIn', CheckIn );

--- a/data/seed.js
+++ b/data/seed.js
@@ -32,7 +32,8 @@ var seedData = {
   ],
 
   access_token: [
-    { id: uuids[ 0 ], ribot_id: uuids[ 0 ], token: utils.encodeToken( uuids[ 0 ] ), last_used_date: date, created_date: date, updated_date: date }
+    { id: uuids[ 0 ], ribot_id: uuids[ 0 ], token: utils.encodeToken( uuids[ 0 ] ), last_used_date: date, created_date: date, updated_date: date },
+    { id: uuids[ 1 ], ribot_id: uuids[ 1 ], token: utils.encodeToken( uuids[ 1 ] ), last_used_date: date, created_date: date, updated_date: date }
   ],
 
   provider_credential: [
@@ -53,6 +54,10 @@ var seedData = {
     { id: uuids[ 5 ], zone_id: uuids[ 0 ], created_date: date, updated_date: date },
     { id: uuids[ 6 ], zone_id: uuids[ 0 ], created_date: date, updated_date: date },
     { id: uuids[ 7 ], zone_id: uuids[ 1 ], created_date: date, updated_date: date }
+  ],
+
+  check_in: [
+    { id: uuids[ 1 ], ribot_id: uuids[ 1 ], label: 'ribot studio', created_date: date, updated_date: date }
   ]
 
 };

--- a/spec/blueprint.md
+++ b/spec/blueprint.md
@@ -1321,6 +1321,44 @@ Retrieve a single check-in.
 
     [Check-in][]
 
+## Modify check-in [/check-ins/{checkInId}]
+
+### Modify check-in [PUT /check-ins/{checkInId}]
+Modifies the given check-in. Currently the only modifiable property is `isCheckedOut` to `true`.
+
++ Parameters
+
+    + checkInId (required, string, `123`) ... Check-in ID.
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: Bearer <token>
+
+    + Body
+
+            {
+              "isCheckedOut": true
+            }
+
+    + Schema
+
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": {
+                "isCheckedOut": {
+                  "description": "If the check-in should be marked as checked out. Currently can only be `true`.",
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+
++ Response 200 (application/json)
+
+    [Check-in][]
+
 ### Retrieve check-in collection [GET /check-ins?ribotId={ribotId}&venueId={venueId}&dateFrom={dateFrom}&dateTo={dateTo}]
 Retrieves a collection of check-ins in date order.
 

--- a/test/mocha/check-in/check-in-test.js
+++ b/test/mocha/check-in/check-in-test.js
@@ -1,4 +1,5 @@
 // External dependencies
+var hat = require( 'hat' );
 
 
 // Dependencies
@@ -183,6 +184,167 @@ describe( 'Check-in', function( done ) {
       shared.shouldNotHaveCheckInForUserInDatabase();
       shared.shouldReturnValidErrorSchema();
       shared.shouldHaveVenueIdError();
+    } );
+
+  } );
+
+  describe( 'Modify Check-in: PUT /check-ins/{checkInId}', function() {
+
+    before( function() {
+
+      this.blueprintRoute = '/check-ins/{checkInId}';
+      this.method = 'put';
+
+    } );
+
+    describe( 'Handle no access token', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, seed.check_in[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 401;
+            this.expectedError = new ResponseError( 'unauthorized' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              body: fixtures.performCheckOutBody
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldNotHaveCheckInForUserInDatabase();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
+    describe( 'Handle unknown check-in ID', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, hat() );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 404;
+            this.expectedError = new ResponseError( 'notFound' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+              },
+              body: fixtures.performCheckOutBody
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldNotHaveCheckInForUserInDatabase();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
+    describe( 'Handle incorrect user access token', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, seed.check_in[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 404;
+            this.expectedError = new ResponseError( 'notFound' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+              },
+              body: fixtures.performCheckOutBody
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldNotHaveCheckInForUserInDatabase();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
+    describe( 'Handle attempting to modify incorrect attributes', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, seed.check_in[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 400;
+            this.expectedError = new ResponseError( 'invalidData' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+              },
+              body: fixtures.performCheckOutBodyInvalid
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldNotHaveCheckInForUserInDatabase();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
+    describe( 'Handle valid request', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, seed.check_in[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            this.expectedStatusCode = 200;
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+              },
+              body: fixtures.performCheckOutBody
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldReturnValidResponseSchema();
+      shared.shouldReturnCheckedOutCheckIn();
+      shared.shouldHaveCheckedOutDateInTheDatabase();
+
     } );
 
   } );

--- a/test/mocha/check-in/fixtures.js
+++ b/test/mocha/check-in/fixtures.js
@@ -57,6 +57,13 @@ module.exports = {
   },
   performCheckInBodyWithInvalidVenueId: {
     "venueId": hat()
+  },
+
+  performCheckOutBody: {
+    "isCheckedOut": true
+  },
+  performCheckOutBodyInvalid: {
+    "label": "A new name"
   }
 
 };

--- a/test/mocha/check-in/shared.js
+++ b/test/mocha/check-in/shared.js
@@ -51,6 +51,27 @@ var shared = {
       this.response.body.errors.length.should.eql( 1 );
       this.response.body.errors[0].property.should.eql( 'venueId' );
     } );
+  },
+
+  shouldReturnCheckedOutCheckIn: function shouldReturnCheckedOutCheckIn() {
+    it( 'should return a check-in object that is marked as checked out', function() {
+      this.response.body.isCheckedOut.should.eql( true );
+    } );
+  },
+
+  shouldHaveCheckedOutDateInTheDatabase: function shouldHaveCheckedOutDateInTheDatabase() {
+    it( 'should have a checked out date in the database', function( done ) {
+      helpers.db.fetch( 'check_in', { ribot_id: seed.ribot[ 1 ].id } )
+        .then( function( results ) {
+          results.length.should.eql( 1 );
+          results[ 0 ].should.have.property( 'checked_out_date' );
+          results[ 0 ].checked_out_date.should.not.be.null();
+          done();
+        } )
+        .catch( function( error ) {
+          done( error );
+        } );
+    } );
   }
 
 };


### PR DESCRIPTION
Checking out is done by performing a PUT to the `/check-ins/:id` endpoint, passing in `IsCheckedOut` as `true`. This will then update the database and return the modified check-in object.

This is up for debate if we think there's a better way to do this.

This is a combination of 3 commits.
- Add the documentation for the new endpoint
- Add the failing tests
- Make the checkout call work
