### PR TITLE
Feature consumer authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=4568
-BASE_URL=http://localhost:4568
+BASE_URL=http://localhost:4569
 LOG_LEVEL=debug
 JWT_SECRET=ribot
 DATABASE_URL=postgresql://vagrant@localhost/ribot-api

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.network "private_network", type: "dhcp"
-  config.vm.network "forwarded_port", guest: 4568, host: 4568
+  config.vm.network "forwarded_port", guest: 4569, host: 4569
 
   config.vm.synced_folder "./", "/home/vagrant/app", type: "nfs"
 

--- a/app/controllers/beacons.js
+++ b/app/controllers/beacons.js
@@ -64,7 +64,6 @@ var createBeaconEncounterPayload = function createBeaconEncounterPayload( beacon
  * Respond with collection of all beacons
  */
 var requestGetBeaconCollection = function requestGetBeaconCollection( request, response, next ) {
-
   var responseData = Beacon.collection().fetch( {
     withRelated: [ 'zone', 'zone.venue' ]
   } )

--- a/app/controllers/beacons.js
+++ b/app/controllers/beacons.js
@@ -2,6 +2,7 @@
 var _ = require( 'lodash' ),
     Promise = require( 'bluebird' );
 
+
 // Dependencies
 var logger = require( '../lib/logger' ),
     router = require( '../lib/router' ),
@@ -28,6 +29,7 @@ var init = function init() {
 
   router.post( '/beacons/:beaconId/encounters',
     middleware.isAuthorized,
+    middleware.requireScopes( 'user' ),
     requestPostBeaconEncounter );
 
 };
@@ -99,7 +101,7 @@ var requestGetBeacon = function requestGetBeacon( request, response, next ) {
 
 
 /**
- * Request POST /beacons/:beaconId/enconters
+ * Request POST /beacons/:beaconId/encounters
  * Respond with collection of all beacons
  */
 var requestPostBeaconEncounter = function requestPostBeaconEncounter( request, response, next ) {

--- a/app/controllers/check-in.js
+++ b/app/controllers/check-in.js
@@ -2,6 +2,7 @@
 var _ = require( 'lodash' ),
     Promise = require( 'bluebird' );
 
+
 // Dependencies
 var logger = require( '../lib/logger' ),
     router = require( '../lib/router' ),
@@ -20,20 +21,24 @@ var init = function init() {
 
   router.post( '/check-ins',
     middleware.isAuthorized,
+    middleware.requireScopes( [ 'checkIn', 'user' ] ),
     middleware.validateBody,
     requestPostCheckIn );
 
   router.get( '/check-ins/:id',
     middleware.isAuthorized,
+    middleware.requireScopes( [ 'checkIn' ] ),
     requestGetCheckIn );
 
   router.put( '/check-ins/:checkInId',
     middleware.isAuthorized,
+    middleware.requireScopes( [ 'checkIn', 'user' ] ),
     middleware.validateBody,
     requestPutCheckIn );
 
   router.get( '/check-ins',
     middleware.isAuthorized,
+    middleware.requireScopes( [ 'checkIn' ] ),
     requestGetCheckInCollection );
 
 };
@@ -125,7 +130,7 @@ var requestPostCheckIn = function requestPostCheckIn( request, response, next ) 
 
 
 /**
- * Request GET /check-in/:id
+ * Request GET /check-ins/:id
  * Responds with the given check-in object
  */
 var requestGetCheckIn = function requestGetCheckIn( request, response, next ) {
@@ -139,7 +144,7 @@ var requestGetCheckIn = function requestGetCheckIn( request, response, next ) {
 
 
 /**
- * Request PUT /check-in/:checkInId
+ * Request PUT /check-ins/:checkInId
  * Responds with the given check-in object that has been modified with the given parameters
  */
 var requestPutCheckIn = function requestPutCheckIn( request, response, next ) {
@@ -175,7 +180,7 @@ var requestPutCheckIn = function requestPutCheckIn( request, response, next ) {
 
 
 /**
- * Request GET /check-in
+ * Request GET /check-ins
  * Receive search parameters and responds with the check-in objects that match
  */
 var requestGetCheckInCollection = function requestGetCheckInCollection( request, response, next ) {

--- a/app/controllers/ribot.js
+++ b/app/controllers/ribot.js
@@ -33,6 +33,7 @@ var init = function init() {
 
   router.get( '/ribots/me',
     middleware.isAuthorized,
+    middleware.requireScopes( 'user' ),
     requestGetAuthenticatedRibot );
 
   router.get( '/ribots/:ribotId',

--- a/app/lib/response-error-list.js
+++ b/app/lib/response-error-list.js
@@ -41,6 +41,10 @@ var errors = {
     message: 'The user is not authorized. The access token may not exist or has expired.',
     statusCode: 401
   },
+  'forbidden': {
+    message: 'This user or application is not permitted to access this resource.',
+    statusCode: 403
+  },
   'notImplemented': {
     message: 'We haven\'t got round to that one yet.',
     statusCode: 501

--- a/app/lib/routing-middleware.js
+++ b/app/lib/routing-middleware.js
@@ -142,11 +142,30 @@ var routeNotFound = function routeNotFound( request, response, next ) {
 };
 
 
+/**
+ * Require scopes
+ */
+var requireScopes = function requireScopesSetup( requiredScopes ) {
+  var scopes = requiredScopes;
+  return function requireScopes( request, response, next ) {
+    var responseError;
+
+    if ( request.user.consumer.hasScopes( scopes ) ) {
+      next();
+    } else {
+      responseError = new ResponseError( 'forbidden' );
+      response.status( responseError.statusCode ).send( responseError );
+    }
+  };
+}
+
+
 // Exports
 module.exports = {
   logRequest: logRequest,
   removeTrailingSlash: removeTrailingSlash,
   isAuthorized: isAuthorized,
   validateBody: validateBody,
-  routeNotFound: routeNotFound
+  routeNotFound: routeNotFound,
+  requireScopes: requireScopes
 };

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -6,7 +6,7 @@ var _ = require( 'lodash' ),
     validate = require( 'validate.js' ),
     validator = require( 'validator' ),
     moment = require( 'moment' ),
-    jwt = require( 'jwt-simple' ),
+    jwt = require( 'jsonwebtoken' ),
     uuid = require( 'node-uuid' );
 
 
@@ -103,8 +103,8 @@ var promisify = function promisify( obj ) {
  * Encodes a given payload (objects/arrays will be JSON stringified)
  */
 var encodeToken = function encodeToken( payload ) {
-  var token = jwt.encode( payload, environment.jwtSecret );
-  return token;
+  var signedToken = jwt.sign( payload, environment.jwtSecret );
+  return signedToken;
 };
 
 
@@ -112,8 +112,10 @@ var encodeToken = function encodeToken( payload ) {
  * Decodes a token back into a payload
  */
 var decodeToken = function decodeToken( token ) {
-  var decoded = jwt.decode( token, environment.jwtSecret );
-  return decoded;
+  var decodedToken = jwt.verify( token, environment.jwtSecret, {
+    ignoreExpiration: true
+  } );
+  return decodedToken;
 };
 
 

--- a/app/models/consumer.js
+++ b/app/models/consumer.js
@@ -1,0 +1,90 @@
+// External dependencies
+var _ = require( 'lodash' );
+
+
+// Dependencies
+var db = require( '../../data' ),
+    environment = require( '../lib/environment' ),
+    utils = require( '../lib/utils' ),
+    BaseModel = require( './base' );
+
+
+/**
+ * BeaconEncounter model
+ */
+var Consumer = BaseModel.extend( {
+
+  tableName: 'consumer',
+
+  hidden: _.union( BaseModel.prototype.hidden, [
+    'secret'
+  ] ),
+
+  virtuals: _.extend( {}, BaseModel.prototype.virtuals, {
+    scopes: {
+      get: function getScopes() {
+        return this.get( 'scopeList' ).split( ' ' );
+      },
+      set: function setScopes( scopes ) {
+        return this.set( 'scopeList', scopes.join( ' ' ) );
+      }
+    }
+  } ),
+
+  validations: {
+    id: {
+      uuid: true
+    }
+  },
+
+  setEvents: function setEvents() {
+    BaseModel.prototype.setEvents.apply( this, arguments );
+    this.on( 'creating', this.setPropertiesBeforeCreate );
+  },
+
+  onBeforeSave: function onBeforeSave( model, attributes, options ) {
+    return BaseModel.prototype.onBeforeSave.apply( this, arguments )
+      .bind( this )
+      .then( function() {
+        var secret = model.get( 'secret' );
+        if ( secret ) {
+          model.set( 'secret', utils.encodeToken( secret ) );
+        }
+      } );
+  },
+
+  onSave: function onSave( model, response, options ) {
+    return BaseModel.prototype.onSave.apply( this, arguments )
+      .bind( this )
+      .then( function() {
+        var secret = model.get( 'secret' );
+        if ( secret ) {
+          model.set( 'secret', utils.decodeToken( secret ) );
+        }
+      } );
+  },
+
+  setPropertiesBeforeCreate: function setPropertiesBeforeCreate( model, attributes, options ) {
+    model.set( 'secret', utils.createUuid() );
+  },
+
+  /**
+   * Checks if the consumer has access to the given scopes
+   */
+  hasScopes: function hasScopes( requiredScopes ) {
+    var scopes = this.get( 'scopes' );
+
+    if ( !_.isString( requiredScopes ) ) {
+      requiredScopes = [ requiredScopes ];
+    }
+
+    return _.every( requiredScopes, function( requiredScope ) {
+      return _.contains( scopes, requiredScope );
+    } );
+  }
+
+} );
+
+
+// Exports
+module.exports = db.bookshelf.model( 'Consumer', Consumer );

--- a/app/models/consumer.js
+++ b/app/models/consumer.js
@@ -74,7 +74,7 @@ var Consumer = BaseModel.extend( {
   hasScopes: function hasScopes( requiredScopes ) {
     var scopes = this.get( 'scopes' );
 
-    if ( !_.isString( requiredScopes ) ) {
+    if ( _.isString( requiredScopes ) ) {
       requiredScopes = [ requiredScopes ];
     }
 

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -3,6 +3,7 @@ require( './access-token' );
 require( './beacon' );
 require( './beacon-encounter' );
 require( './check-in' );
+require( './consumer' );
 require( './ribot' );
 require( './provider-credential' );
 require( './zone' );

--- a/data/migrations/7-add-consumer-table.js
+++ b/data/migrations/7-add-consumer-table.js
@@ -1,0 +1,30 @@
+// External ependancies
+var Promise = require( 'bluebird' );
+
+
+// Dependencies
+var db = require( '../index' );
+
+
+// Local variables
+var consumerSchema = {
+  primary: 'id',
+  columns: {
+    id:                      { type: 'uuid' },
+    name:                    { type: 'text', nullable: false, unique: true },
+    scope_list:              { type: 'text', nullable: false },
+    secret:                  { type: 'text', nullable: false },
+    created_date:            { type: 'dateTime', nullable: false },
+    updated_date:            { type: 'dateTime', nullable: false }
+  }
+};
+
+
+// Migrate function
+var migrate = function migrate( trx ) {
+  return db.createTable( 'consumer', consumerSchema, null, trx );
+};
+
+
+// Exports
+module.exports = migrate;

--- a/data/migrations/index.js
+++ b/data/migrations/index.js
@@ -12,5 +12,6 @@ module.exports = {
   3: require( './3-add-venue-table' ),
   4: require( './4-add-checkin-venueid-foreign-key' ),
   5: require( './5-add-beacon-checkin-tables' ),
-  6: require( './6-add-ibeacon-columns' )
+  6: require( './6-add-ibeacon-columns' ),
+  7: require( './7-add-consumer-table' )
 };

--- a/data/schema.js
+++ b/data/schema.js
@@ -10,6 +10,18 @@ var schema = {
     }
   },
 
+  consumer: {
+    primary: 'id',
+    columns: {
+      id:                      { type: 'uuid' },
+      name:                    { type: 'text', nullable: false, unique: true },
+      scope_list:              { type: 'text', nullable: false },
+      secret:                  { type: 'text', nullable: false },
+      created_date:            { type: 'dateTime', nullable: false },
+      updated_date:            { type: 'dateTime', nullable: false }
+    }
+  },
+
   ribot: {
     primary: 'id',
     columns: {

--- a/data/seed.js
+++ b/data/seed.js
@@ -28,7 +28,8 @@ var seedData = {
 
   consumer: [
     { id: uuids[ 0 ], name: 'Test app', scope_list: 'user checkIn', secret: utils.encodeToken( uuids[ 0 ] ), created_date: date, updated_date: date },
-    { id: uuids[ 1 ], name: 'Test app 2', scope_list: 'checkIn', secret: utils.encodeToken( uuids[ 1 ] ), created_date: date, updated_date: date }
+    { id: uuids[ 1 ], name: 'Test app 2', scope_list: 'checkIn', secret: utils.encodeToken( uuids[ 1 ] ), created_date: date, updated_date: date },
+    { id: uuids[ 2 ], name: 'Test app 3', scope_list: '', secret: utils.encodeToken( uuids[ 2 ] ), created_date: date, updated_date: date }
   ],
 
   ribot: [

--- a/data/seed.js
+++ b/data/seed.js
@@ -23,7 +23,13 @@ var date = moment().format(),
       return utils.createUuid();
     } );
 
+
 var seedData = {
+
+  consumer: [
+    { id: uuids[ 0 ], name: 'Test app', scope_list: 'user checkIn', secret: utils.encodeToken( uuids[ 0 ] ), created_date: date, updated_date: date },
+    { id: uuids[ 1 ], name: 'Test app 2', scope_list: 'checkIn', secret: utils.encodeToken( uuids[ 1 ] ), created_date: date, updated_date: date }
+  ],
 
   ribot: [
     { id: uuids[ 0 ], first_name: 'Robert', last_name: 'Douglas', email: 'rob@douglas.com', date_of_birth: '1970-01-01', avatar: 'http://exmaple.com/avatar.png', hex_color: '#C0FFEE', is_authenticated: true, created_date: date, updated_date: date },

--- a/data/seed.js
+++ b/data/seed.js
@@ -1,7 +1,6 @@
 // External Dependencies
 var moment = require( 'moment' ),
-    _ = require( 'lodash' ),
-    jwt = require( 'jwt-simple' );
+    _ = require( 'lodash' );
 
 
 // Dependencies

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^1.2.0",
     "express": "^4.13.3",
     "googleapis": "^1.1.5",
+    "jsonwebtoken": "^5.4.1",
     "jwt-simple": "^0.3.1",
     "knex": "^0.6.22",
     "lodash": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "express": "^4.13.3",
     "googleapis": "^1.1.5",
     "jsonwebtoken": "^5.4.1",
-    "jwt-simple": "^0.3.1",
     "knex": "^0.6.22",
     "lodash": "^3.10.1",
     "moment": "^2.10.6",

--- a/test/mocha/beacons/beacons-test.js
+++ b/test/mocha/beacons/beacons-test.js
@@ -1,5 +1,6 @@
 // External dependencies
-var moment = require( 'moment' );
+var moment = require( 'moment' ),
+jwt = require( 'jsonwebtoken' );
 
 
 // Dependencies
@@ -60,7 +61,7 @@ describe( 'Beacons', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               }
             }, done );
           }.bind( this ) );
@@ -125,7 +126,7 @@ describe( 'Beacons', function( done ) {
                 method: this.method,
                 route: this.route,
                 headers: {
-                  'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                  'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                 }
               }, done );
             }.bind( this ) );
@@ -153,7 +154,7 @@ describe( 'Beacons', function( done ) {
                 method: this.method,
                 route: this.route,
                 headers: {
-                  'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                  'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                 }
               }, done );
             }.bind( this ) );
@@ -221,7 +222,7 @@ describe( 'Beacons', function( done ) {
                 method: this.method,
                 route: this.route,
                 headers: {
-                  'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                  'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                 }
               }, done );
             }.bind( this ) );
@@ -254,7 +255,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );
@@ -287,7 +288,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );
@@ -321,7 +322,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );
@@ -354,7 +355,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );
@@ -388,7 +389,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );
@@ -421,7 +422,7 @@ describe( 'Beacons', function( done ) {
                   method: this.method,
                   route: this.route,
                   headers: {
-                    'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                    'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
                   }
                 }, done );
               }.bind( this ) );

--- a/test/mocha/beacons/beacons-test.js
+++ b/test/mocha/beacons/beacons-test.js
@@ -176,6 +176,36 @@ describe( 'Beacons', function( done ) {
       this.method = 'post';
     } );
 
+    describe( 'Handle consumer without the required scope permissions', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{beaconUuid\}/g, seed.beacon[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 403;
+            this.expectedError = new ResponseError( 'forbidden' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ], seed.consumer[ 1 ] )
+              }
+            }, done );
+          }.bind( this ) );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldReturnValidErrorSchema();
+      shared.shouldHaveNoBeaconEncounters();
+
+    } );
+
     describe( 'Handle invalid access token', function() {
 
       before( function( done ) {

--- a/test/mocha/beacons/beacons-test.js
+++ b/test/mocha/beacons/beacons-test.js
@@ -1,6 +1,5 @@
 // External dependencies
-var moment = require( 'moment' ),
-jwt = require( 'jsonwebtoken' );
+var moment = require( 'moment' );
 
 
 // Dependencies

--- a/test/mocha/check-in/check-in-test.js
+++ b/test/mocha/check-in/check-in-test.js
@@ -109,11 +109,34 @@ describe( 'Check-in', function( done ) {
 
     } );
 
+    describe( 'Handle consumer without the required scope permissions', function() {
+
+      before( function( done ) {
+        // Set up scope for assertions
+        this.expectedStatusCode = 403;
+        this.expectedError = new ResponseError( 'forbidden' );
+
+        // Make request
+        helpers.request.bind( this )( {
+          method: this.method,
+          route: this.route,
+          headers: {
+            'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ], seed.consumer[ 2 ] )
+          }
+        }, done );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
     describe( 'Handle with just label', function( done ) {
       testWithValidAndInvalidAccessTokensAndBody( fixtures.performCheckInBodyWithLabel );
     } );
 
-    describe( 'Hanel with label and coordinates', function( done ) {
+    describe( 'Handle with label and coordinates', function( done ) {
       testWithValidAndInvalidAccessTokensAndBody( fixtures.performCheckInBodyWithAndLocation );
     } );
 
@@ -125,27 +148,27 @@ describe( 'Check-in', function( done ) {
 
       describe( 'Handle only latitude', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyOnlyLatitude );
-      });
+      } );
 
       describe( 'Handle only longitude', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyOnlyLongitude );
-      });
+      } );
 
       describe( 'Handle invalid latitude (low)', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyInvalidLatitudeLow );
-      });
+      } );
 
       describe( 'Handle invalid latitude (high)', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyInvalidLatitudeHigh );
-      });
+      } );
 
       describe( 'Handle invalid longitude (low)', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyInvalidLongitudeLow );
-      });
+      } );
 
       describe( 'Handle invalid longitude (high)', function( done ) {
         testInvalidDataErrorWithBody( fixtures.performCheckInBodyInvalidLongitudeHigh );
-      });
+      } );
 
     } );
 
@@ -193,6 +216,36 @@ describe( 'Check-in', function( done ) {
 
       this.blueprintRoute = '/check-ins/{checkInId}';
       this.method = 'put';
+
+    } );
+
+    describe( 'Handle consumer without the required scope permissions', function() {
+
+      before( function( done ) {
+        this.route = this.blueprintRoute.replace( /\{checkInId\}/g, seed.check_in[ 0 ].id );
+
+        // Set up db tables and seed
+        helpers.db.setupForTests()
+          .then( function() {
+            // Set up scope for assertions
+            this.expectedStatusCode = 403;
+            this.expectedError = new ResponseError( 'forbidden' );
+
+            // Make request
+            helpers.request.bind( this )( {
+              method: this.method,
+              route: this.route,
+              headers: {
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ], seed.consumer[ 2 ] )
+              }
+            }, done );
+          }.bind( this ) );
+
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldReturnValidErrorSchema();
 
     } );
 

--- a/test/mocha/check-in/check-in-test.js
+++ b/test/mocha/check-in/check-in-test.js
@@ -49,7 +49,7 @@ var testWithValidAndInvalidAccessTokensAndBody = function testWithValidAndInvali
             method: this.method,
             route: this.route,
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             },
             body: requestBody
           }, done );
@@ -82,7 +82,7 @@ var testInvalidDataErrorWithBody = function testInvalidDataErrorWithBody( reques
           method: this.method,
           route: this.route,
           headers: {
-            'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+            'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
           },
           body: requestBody
         }, done );
@@ -171,7 +171,7 @@ describe( 'Check-in', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               },
               body: fixtures.performCheckInBodyWithInvalidVenueId
             }, done );
@@ -241,7 +241,7 @@ describe( 'Check-in', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               },
               body: fixtures.performCheckOutBody
             }, done );
@@ -272,7 +272,7 @@ describe( 'Check-in', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 0 ].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               },
               body: fixtures.performCheckOutBody
             }, done );
@@ -303,7 +303,7 @@ describe( 'Check-in', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 1 ] )
               },
               body: fixtures.performCheckOutBodyInvalid
             }, done );
@@ -332,7 +332,7 @@ describe( 'Check-in', function( done ) {
               method: this.method,
               route: this.route,
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[ 1 ].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 1 ] )
               },
               body: fixtures.performCheckOutBody
             }, done );

--- a/test/mocha/helpers/index.js
+++ b/test/mocha/helpers/index.js
@@ -6,7 +6,8 @@ var url = require( 'url' ),
     fs = require( 'fs' ),
     BlueprintSchema = require( 'api-blueprint-json-schema' ),
     moment = require( 'moment' ),
-    nock = require( 'nock' );
+    nock = require( 'nock' ),
+    jwt = require( 'jsonwebtoken' );
 
 
 // Dependencies
@@ -153,7 +154,7 @@ var helpers = {
 
   },
 
-  request: function ( options, done ) {
+  request: function( options, done ) {
     var requestOptions = {},
         requestObject,
         requestForm;
@@ -185,8 +186,20 @@ var helpers = {
   /**
    * Is valid date utility
    */
-  isValidDate: function( date ) {
+  isValidDate: function isValidDate( date ) {
     return moment( date, [ 'ddd, DD MMM YYYY HH:mm:ss ZZ' ] ).isValid();
+  },
+
+  /**
+   * Sign a JWT with a given accessToken record and consumer record
+   */
+  signJwt: function testFn( accessToken, consumer ) {
+    consumer = consumer || seed.consumer[ 0 ];
+
+    return jwt.sign( {
+      key: consumer.id,
+      accessToken: utils.decodeToken( accessToken.token )
+    }, utils.decodeToken( consumer.secret ) );
   }
 
 };

--- a/test/mocha/index-test.js
+++ b/test/mocha/index-test.js
@@ -1,9 +1,9 @@
 // Set up code coverage
-require( 'blanket' )( {
-    pattern: function ( filename ) {
-        return !/node_modules/.test( filename ) && !/test/.test( filename );
-    }
-} );
+// require( 'blanket' )( {
+//     pattern: function ( filename ) {
+//         return !/node_modules/.test( filename ) && !/test/.test( filename );
+//     }
+// } );
 
 
 // External dependencies

--- a/test/mocha/index-test.js
+++ b/test/mocha/index-test.js
@@ -1,9 +1,9 @@
 // Set up code coverage
-// require( 'blanket' )( {
-//     pattern: function ( filename ) {
-//         return !/node_modules/.test( filename ) && !/test/.test( filename );
-//     }
-// } );
+require( 'blanket' )( {
+    pattern: function ( filename ) {
+        return !/node_modules/.test( filename ) && !/test/.test( filename );
+    }
+} );
 
 
 // External dependencies

--- a/test/mocha/ribot/ribot-test.js
+++ b/test/mocha/ribot/ribot-test.js
@@ -23,6 +23,29 @@ var fullRibotRoutesTestSuite = function fullRibotRoutesTestSuite( expectSomeChec
       this.method = 'get';
     } );
 
+    describe( 'Handle consumer without the required scope permissions', function() {
+
+      before( function( done ) {
+        // Set up scope for assertions
+        this.expectedStatusCode = 403;
+        this.expectedError = new ResponseError( 'forbidden' );
+
+        // Make request
+        helpers.request.bind( this )( {
+          method: this.method,
+          route: this.route,
+          headers: {
+            'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ], seed.consumer[ 1 ] )
+          }
+        }, done );
+      } );
+
+      shared.shouldRespondWithCorrectStatusCode();
+      shared.shouldRespondWithCorrectError();
+      shared.shouldReturnValidErrorSchema();
+
+    } );
+
     describe( 'Handle invalid access token', function() {
 
       before( function( done ) {

--- a/test/mocha/ribot/ribot-test.js
+++ b/test/mocha/ribot/ribot-test.js
@@ -55,7 +55,7 @@ var fullRibotRoutesTestSuite = function fullRibotRoutesTestSuite( expectSomeChec
             method: this.method,
             route: this.route,
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             }
           }, done );
         } );
@@ -79,7 +79,7 @@ var fullRibotRoutesTestSuite = function fullRibotRoutesTestSuite( expectSomeChec
               embed: 'checkins'
             },
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             }
           }, done );
         } );
@@ -169,7 +169,7 @@ var fullRibotRoutesTestSuite = function fullRibotRoutesTestSuite( expectSomeChec
             },
             route: this.route,
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             }
           }, done );
         } );
@@ -290,7 +290,7 @@ var fullRibotRoutesTestSuite = function fullRibotRoutesTestSuite( expectSomeChec
             },
             route: this.route,
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             }
           }, done );
         } );
@@ -345,7 +345,7 @@ describe( 'ribot collection', function( done ) {
               method: 'post',
               route: '/check-ins',
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               },
               body: {
                 label: 'Home'
@@ -364,7 +364,7 @@ describe( 'ribot collection', function( done ) {
             method: 'post',
             route: '/check-ins',
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             },
             body: {
               venueId: seed.venue[0].id
@@ -388,7 +388,7 @@ describe( 'ribot collection', function( done ) {
               method: 'post',
               route: '/beacons/' + seed.beacon[ 0 ].id + '/encounters',
               headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               }
             }, function( err ) {
               if ( err ) {
@@ -404,7 +404,7 @@ describe( 'ribot collection', function( done ) {
             method: 'post',
             route: '/check-ins',
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             },
             body: {
               venueId: seed.venue[0].id

--- a/test/mocha/venue/venue-test.js
+++ b/test/mocha/venue/venue-test.js
@@ -59,7 +59,7 @@ describe( 'Venue collections', function( done ) {
           method: this.method,
           route: this.route,
           headers: {
-            'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+            'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
           }
         }, done );
       } );
@@ -117,7 +117,7 @@ describe( 'Venue collections', function( done ) {
             method: this.method,
             route: this.route,
             headers: {
-              'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+              'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
             }
           }, done );
         } );
@@ -144,7 +144,7 @@ describe( 'Venue collections', function( done ) {
             method: this.method,
             route: this.route,
             headers: {
-                'Authorization': 'Bearer ' + utils.decodeToken( seed.access_token[0].token )
+                'Authorization': 'Bearer ' + helpers.signJwt( seed.access_token[ 0 ] )
               }
           }, done );
         } );


### PR DESCRIPTION
This is to give more granular control over what permissions apps (consumers) have access to. For instance, a dashboard app may require access to private API data, but cannot perform any user interactions (as a user may not be associated with the app).

Consumers will now have to be registered in the database with the desired scope permissions (see schema).

To make an API request, sign a JWT with your consumer `secret` and include the consumer `key` and `accessToken` (optional, only required if a user is involved).

```
// Sign this with HS256 and your consumer secret (don't include any expiration date)
{
  "key": "123",
  "accessToken": "abc"
}
```
